### PR TITLE
Small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Transparency in Coverage
-The technical implementation guide for the machine readable files as required by the [Transparency in Coverage](https://www.federalregister.gov/documents/2019/11/27/2019-25011/transparency-in-coverag) final rules (85 FR 72158).
+The technical implementation guide for the machine readable files as required by the [Transparency in Coverage](https://www.federalregister.gov/documents/2019/11/27/2019-25011/transparency-in-coverag) final rules ([85 FR 72158](https://www.govinfo.gov/app/details/FR-2020-11-12/2020-24591)).
 
 Overview
 ========
@@ -10,7 +10,7 @@ All machine-readable files must conform to a non-proprietary, open standards for
 Background
 ==========
 
-The Departments of the Treasury, Labor, and Health and Human Services (the Departments) have issued the Transparency in Coverage final rules (85 FR 72158) on November 12, 2020. The final rules require non-grandfathered group health plans and health insurance issuers in the individual and group markets (plans and issuers) to disclose certain pricing information. Under the final rules a plan or issuer must disclose in-network negotiated rates, billed and out-of-network allowed, and in-network drug prices (including both “negotiated rates” and “historical net prices”) through three machine-readable files posted on an internet website.  
+The Departments of the Treasury, Labor, and Health and Human Services (the Departments) have issued the Transparency in Coverage final rules (85 FR 72158) on November 12, 2020. The final rules require non-grandfathered group health plans and health insurance issuers in the individual and group markets (plans and issuers) to disclose certain pricing information. Under the final rules a plan or issuer must disclose in-network negotiated rates, billed and out-of-network allowed, and in-network drug prices (including both "negotiated rates" and "historical net prices") through three machine-readable files posted on an internet website.  
 
 Plans and issuers are required to make these files public for plan or policy years beginning on or after January 1, 2022.
 
@@ -111,6 +111,6 @@ Getting Involved
 
 The healthcare ecosystem is complex with what seems like an infinite amount of plan and issuer implementations. There are no doubt going to be questions for these various situations and the requirements found in the Transparency in Coverage rule. Currently, there are two ways in which the community can get involved:
 * [Github Issues](https://guides.github.com/features/issues/) - Where people discuss issues related to the project.
-* [Github Discussions](https://github.com/CMSgov/price-transparency-guide/discussions) - Use these channels for conversational topics (for example, “How do I…“ or “What do you think about…“ instead of bug reports or feature requests).
+* [Github Discussions](https://github.com/CMSgov/price-transparency-guide/discussions) - Use these channels for conversational topics (for example, "How do I&hellip;" or "What do you think about&hellip;" instead of bug reports or feature requests).
 
 Before posting a comment, issue, or question, please search through existing discussions and issues. There is a good chance that the topic in questions is already being discussed.


### PR DESCRIPTION
1. Add https://www.govinfo.gov/app/details/FR-2020-11-12/2020-24591 as a link for `85 FR 72158`
1. Replace smart quote `“` and `”` with `"` as expected by HTML / CSS / Markdown 
1. Replace unicode horizontal ellipsis literal `…` with entity `&hellip;` for improved RTL, improved font support, improved blind reader support

I cannot tell you how much I love that this is on Github