### PR TITLE
Fix non-compliant array notation in schema

### DIFF
--- a/schemas/allowed-amounts/README.md
+++ b/schemas/allowed-amounts/README.md
@@ -74,6 +74,6 @@ Negotiated rates for items and services can come from a variety of billing code 
 | All Patient Refined Diagnosis Related Groups | APR-DRG | [AHRQ documentation](https://www.hcup-us.ahrq.gov/db/nation/nis/APR-DRGsV20MethodologyOverviewandBibliography.pdf) |
 | Ambulatory Payment Classifications | APC | [APC background information](https://www.acep.org/administration/reimbursement/reimbursement-faqs/apc-ambulatory-payment-classifications-faq/#question0) |
 | Local Processing  | LOCAL | |
-| Enhanced Ambulatory Patient Grouping | EAPG | |
-| Health Insurance Prospective Payment System | HIPPS | | 
-| Current Dental Terminology | CDT | | 
+| Enhanced Ambulatory Patient Grouping | EAPG |[EAPG](https://www.3m.com/3M/en_US/health-information-systems-us/drive-value-based-care/patient-classification-methodologies/enhanced-apgs/) |
+| Health Insurance Prospective Payment System | HIPPS | [HIPPS](https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/ProspMedicareFeeSvcPmtGen/HIPPSCodes)| 
+| Current Dental Terminology | CDT | [CDT](https://www.ada.org/en/publications/cdt)  | 

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -12,17 +12,17 @@
         "description": { "type": "string" },
         "negotiated_rates": {
           "type": "array",
-          "$ref": "#/definitions/negotiated_rates",
+          "items": { "$ref": "#/definitions/negotiated_rates" },
           "default": []
         },
         "covered_services": {
           "type": "array",
-          "$ref": "#/definitions/covered_services",
+          "items": { "$ref": "#/definitions/covered_services" },
           "default": []
         },
         "bundled_codes": {
           "type": "array",
-          "$ref": "#/definitions/bundle_codes",
+          "items": { "$ref": "#/definitions/bundle_codes" },
           "default": []
         }
       },


### PR DESCRIPTION
When using this schema to validate generated files we detected that the schema itself was failing to validate/load.    Once the array notation was corrected this schema could be used for validation.

Additionally, while reviewing the readme documentation for the allowed amounts and in-network rates schemas we discovered the billing code type table was missing references.