### PR TITLE
Empty allowed amounts

### DIFF
--- a/examples/allowed-amounts/allowed-amounts-empty.json
+++ b/examples/allowed-amounts/allowed-amounts-empty.json
@@ -1,0 +1,13 @@
+{
+   "reporting_entity_name": "medicare",
+   "reporting_entity_type": "medicare",
+   "reporting_plans":[{
+     "plan_name": "medicare",
+     "plan_id_type": "hios",
+     "plan_id": "11111111111,
+     "plan_market_type": "individual"
+   }],
+   "last_updated_on": "2020-08-27",
+   "version": "1.0.0",
+   "out_of_network":[]
+}

--- a/examples/allowed-amounts/allowed-amounts-empty.json
+++ b/examples/allowed-amounts/allowed-amounts-empty.json
@@ -4,7 +4,7 @@
    "reporting_plans":[{
      "plan_name": "medicare",
      "plan_id_type": "hios",
-     "plan_id": "11111111111,
+     "plan_id": "11111111111",
      "plan_market_type": "individual"
    }],
    "last_updated_on": "2020-08-27",


### PR DESCRIPTION
An example for the allowed amounts file when all out of network claims are fewer than 20.