### PR TITLE
Update in-network-rates-capitation-sample.json

### DIFF
--- a/examples/in-network-rates/in-network-rates-capitation-sample.json
+++ b/examples/in-network-rates/in-network-rates-capitation-sample.json
@@ -18,6 +18,9 @@
     "negotiation_arrangement": "capitation",
     "name": "Primary Care Capitation",
     "description": "Typical items and services for a primary care provider",
+    "billing_code_type": "CPT",
+    "billing_code_type_version": "2020",
+    "billing_code": "27447",
     "negotiated_rates": [{
       "provider_groups": [{
         "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],


### PR DESCRIPTION
Capitation example does not align with in-network schema--missing the in-network billing code data