### PR TITLE
TOC sample, in_network_files should be an array

### DIFF
--- a/examples/table-of-contents/table-of-contents-sample.json
+++ b/examples/table-of-contents/table-of-contents-sample.json
@@ -31,10 +31,10 @@
        "plan_id": "33333333333",
        "plan_market_type": "group"
      }],
-     "in_network_file": {
+     "in_network_files": [{
        "description": "in-network file",
        "location": "https://www.some_site.com/files/chip-in-network-file.json"
-     },
+     }],
      "allowed_amount_file": {
        "description": "allowed amount file",
        "location": "https://www.some_site.com/files/chip-allowed-amount-file.json"


### PR DESCRIPTION
The second instance of in_network_files is not an array. Does not comply with schema. Changing it to an array.