### PR TITLE
Fixing documentation bug for 'description'. Issue: https://github.com…

### DIFF
--- a/schemas/in-network-rates/README.md
+++ b/schemas/in-network-rates/README.md
@@ -27,7 +27,7 @@ This type defines an in-network object.
 | **billing_code_type** | Billing Code Type | String | Common billing code types. Please see a list of the [currently allowed codes](#additional-notes-concerning-billing_code_type) at the bottom of this document. | Yes |
 | **billing_code_type_version** | Billing Code Type Version | String | There might be versions associated with the `billing_code_type`. For example, Medicare's current (as of 5/24/21) MS-DRG version is 37.2 | Yes |
 | **billing_code** | Billing Code | String | The code used by a plan or issuer or its in-network providers to identify health care items or services for purposes of billing, adjudicating, and paying claims for a covered item or service. If a custom code is used for `billing_code_type`, please refer to [custom billing code values](#additional-notes-concerning-billing_code) |  Yes |
-| **description** | Description | String | Brief description of the item/service | No |
+| **description** | Description | String | Brief description of the item/service | Yes |
 | **negotiated_rates** | Negotiated Rates | Array | This is an array of [negotiated rate details object types](#negotiated-rate-details-object) | Yes |
 | **bundled_codes** | Bundled Codes | Array | This is an array of [bundle code objects](#bundle-code-object). This array contains all the different codes in a bundle if `bundle` is selected for `negotiation_arrangement` | No |
 | **covered_services** | Covered Service | Array | This is an array of [covered services objects](#covered-services-object). This array contains all the different codes in a capitation arrangement if `capitation` is selected for `negotiation_arrangement` | No |


### PR DESCRIPTION
Issue: https://github.com/CMSgov/price-transparency-guide/issues/427

Updating from "optional" to "required" in the documentation. This was already defined in the schema.