### PR TITLE
updating documentation to clarify that NPI type 2s can be used for reporting

### DIFF
--- a/schemas/in-network-rates/README.md
+++ b/schemas/in-network-rates/README.md
@@ -64,7 +64,7 @@ Either a `provider_groups` or `provider_references` attribute will be required i
 #### Providers Object
 | Field | Name | Type | Definition | Required |
 | ----- | ---- | ---- | ---------- | -------- |
-| **npi** | NPI | Array | An array of individual (type 1) provider identification numbers (NPI). | Yes |
+| **npi** | NPI | Array | An array of National Provider Identifiers (NPIs). The NPI array attribute can contain a mix of Type 1 and Type 2 NPIs, both of which must be provided, if available. In contractual arrangements with Type 2 NPIs where Type 1 NPIs are unknown or otherwise unavailable, only the Type 2 NPIs must be reported. | Yes |
 | **tin** | Tax Identification Number | Object | The [tax identifier object](#tas-identifier-object) contains tax information on the place of business | Yes |
 
 #### Tax Identifier Object

--- a/schemas/provider-reference/README.md
+++ b/schemas/provider-reference/README.md
@@ -9,8 +9,8 @@ The schema has a single root object vs an array to accommodate formats that may 
 #### Providers Object
 | Field | Name | Type | Definition | Required |
 | ----- | ---- | ---- | ---------- | -------- |
-| **npi** | NPI | Array | An array of individual (type 1) provider identification numbers (NPI). | Yes |
-| **tin** | Tax Identification Number | Object | The [tax identifier object](#tas-identifier-object) contains tax information on the place of business | Yes |
+| **npi** | NPI | Array | An array of National Provider Identifiers (NPIs). The NPI array attribute can contain a mix of Type 1 and Type 2 NPIs, both of which must be provided, if available. In contractual arrangements with Type 2 NPIs where Type 1 NPIs are unknown or otherwise unavailable, only the Type 2 NPIs must be reported. | Yes |
+| **tin** | Tax Identification Number | Object | The [tax identifier object](#tax-identifier-object) contains tax information on the place of business | Yes |
 
 #### Tax Identifier Object
 | Field | Name | Type | Definition | Required |


### PR DESCRIPTION
Impacts in-network files and provider-reference files.

Related discussions: https://github.com/CMSgov/price-transparency-guide/discussions/273, https://github.com/CMSgov/price-transparency-guide/discussions/14#discussioncomment-778198