### PR TITLE
Update schema version in example file

### DIFF
--- a/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
@@ -6,7 +6,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "provider_references":[{
     "provider_group_id": 1,
     "provider_groups": [{


### PR DESCRIPTION
## Background

The `version` field of the `in-network-rates` file should specify "The version of the schema for the produced information" ([docs](https://github.com/cphbrt/price-transparency-guide/tree/master/schemas/in-network-rates#in-network-file)).

## Problem

The value in the `version` field of `examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json` is `1.0.0`. It should be at least `1.2.0`.

## How we know

### 1. via Git history

[Comparing tag v1.1.2 to tag v1.2.0](https://github.com/CMSgov/price-transparency-guide/compare/v1.1.2...v1.2.0), we see that `"CSTM-00"` was added to the enum of valid `service_code` values and, simultaneously, `"CSTM-00"` was added to the example file thereby making the example file dependent on version `1.2.0` (tag `v1.2.0`) of the schema (or newer).

### 2. via validator

After setup of the validator repo...

```
√ ~/external/CMSgov/price-transparency-guide-validator
% node out/index.js from-url https://raw.githubusercontent.com/CMSgov/price-transparency-guide/master/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json v1.2.0 -t in-network-rates -s
Beginning download...
content type text/plain; charset=utf-8
Download complete.
Input JSON is valid.
```

... validation succeeds for the file-of-concern using version 1.2.0 or above.

And fails for version 1.1.2 or below.
```
√ ~/external/CMSgov/price-transparency-guide-validator
% node out/index.js from-url https://raw.githubusercontent.com/CMSgov/price-transparency-guide/master/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json v1.1.2 -t in-network-rates -s
Beginning download...
content type text/plain; charset=utf-8
Download complete.
Input JSON is invalid.
Error Name: enum
Message: Property has a value that is not one of its allowed enumerated values.
Instance: #/in_network/1/negotiated_rates/0/negotiated_prices/0/service_code/0
Schema: #/definitions/negotiated_price/properties/service_code/items


Invalid schema: #/definitions/negotiated_price/properties/service_code/items
Invalid keyword: enum
Invalid code: 19
Invalid message: Property has a value that is not one of its allowed enumerated values.
Invalid document: #/in_network/1/negotiated_rates/0/negotiated_prices/0/service_code/0
Error report:
{
    "enum": {
        "errorCode": 19,
        "instanceRef": "#/in_network/1/negotiated_rates/0/negotiated_prices/0/service_code/0",
        "schemaRef": "#/definitions/negotiated_price/properties/service_code/items"
    }
}
```

## Resolution

The change in this PR brings the example file's `version` field into agreement with the schema version defining its contents. This way, future consumers of the example file will have the appropriate clues to realize they must use validator `v1.2.0` or greater to validate this example file.

Relatedly, we should update the schema version in [example usages in the validator README](https://github.com/CMSgov/price-transparency-guide-validator#validate-a-file). I'll make a separate PR for that.

-----

This is my first PR to this repo. Happy to make any changes. Thanks!