### PR TITLE
Add "both" billing class in a certain place

### DIFF
--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -449,6 +449,15 @@
               ]
             }
           }
+        },
+        {
+          "properties": {
+            "billing_class": {
+              "enum": [
+                "both"
+              ]
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
It appears to me that based on the spec, this entry needs to be here? I'm not very familair with JSON schema and could be wrong though. I have a client that is presenting "both" for the billing_class via the negotiated_rates object, but it fails validation. 