### PR TITLE
Common Provider Network Name

### DIFF
--- a/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
@@ -11,6 +11,7 @@
   "provider_references": [
     {
       "provider_group_id": 1,
+      "network_name": "ACME Choice Provider Group",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],
@@ -30,6 +31,7 @@
     },
     {
       "provider_group_id": 2,
+      "network_name": "ACME Choice Provider Group Plus",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],

--- a/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
@@ -10,6 +10,7 @@
   "provider_references": [
     {
       "provider_group_id": 1,
+      "network_name": "ACME Choice Provider Group",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],
@@ -29,6 +30,7 @@
     },
     {
       "provider_group_id": 2,
+      "network_name": "ACME Choice Provider Group Plus",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],

--- a/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
@@ -12,6 +12,7 @@
   "provider_references": [
     {
       "provider_group_id": 1,
+      "network_name": "ACME Choice Provider Group",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],
@@ -31,6 +32,7 @@
     },
     {
       "provider_group_id": 2,
+      "network_name": "ACME Choice Provider Group Plus",
       "provider_groups": [
         {
           "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],

--- a/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
+++ b/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "provider_references":[{
     "provider_group_id": 1,
+    "network_name": "ACME Choice Provider Group",
     "provider_groups": [{
       "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],
       "tin":{
@@ -20,6 +21,7 @@
     }]
   },{
     "provider_group_id": 2,
+    "network_name": "ACME Choice Provider Group Plus",
     "provider_groups": [{
       "npi": [1111111111, 2222222222, 3333333333, 4444444444, 5555555555],
       "tin":{

--- a/examples/in-network-rates/in-network-rates-no-npi.json
+++ b/examples/in-network-rates/in-network-rates-no-npi.json
@@ -12,6 +12,7 @@
   "provider_references": [
     {
       "provider_group_id": 1,
+      "network_name": "ACME Choice Provider Group",
       "provider_groups": [
         {
           "npi": [0],

--- a/schemas/in-network-rates/README.md
+++ b/schemas/in-network-rates/README.md
@@ -75,6 +75,7 @@ This type defines a provider reference object. This object is used in the `provi
 | Field | Name | Type | Definition | Required |
 | ----- | ---- | ---- | ---------- | -------- |
 | **provider_group_id** | Provider Group Id | Number | The unique, primary key for the associated `provider_group` object | Yes |
+| **network_name** | Network Name | String | The common provider network name for the provider group | Yes |
 | **provider_groups** | Provider Groups | Array  | The [providers object](#providers-object) defines information about the provider and their associated TIN related to the negotiated price. | Yes |
 
 #### Negotiated Price Object

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -308,9 +308,13 @@
             },
             "default": [],
             "minItems": 1
+          },
+          "network_name": {
+            "type": "string",
+            "minLength": 1
           }
         },
-        "required": ["provider_group_id", "provider_groups"]
+        "required": ["provider_group_id", "provider_groups", "network_name"]
       },
       "minLength": 1
     },


### PR DESCRIPTION
Including a required attribute to include the provider network name for a `provider_group`.