### PR TITLE
adding plan_sponsor_name documentation for the ToC

### DIFF
--- a/examples/table-of-contents/table-of-contents-sample.json
+++ b/examples/table-of-contents/table-of-contents-sample.json
@@ -8,12 +8,14 @@
         {
           "plan_name": "medicaid",
           "plan_id_type": "hios",
+          "issuer_name": "CMS",
           "plan_id": "1111111111",
           "plan_market_type": "individual"
         },
         {
           "plan_name": "medicare",
           "plan_id_type": "hios",
+          "issuer_name": "CMS",
           "plan_id": "000000000",
           "plan_market_type": "individual"
         }
@@ -38,6 +40,7 @@
         {
           "plan_name": "chip",
           "plan_id_type": "hios",
+          "issuer_name": "CMS",
           "plan_id": "3333333333",
           "plan_market_type": "group"
         }

--- a/schemas/table-of-contents/README.md
+++ b/schemas/table-of-contents/README.md
@@ -24,8 +24,9 @@ At [least one](https://github.com/CMSgov/price-transparency-guide/blob/master/sc
 | Field | Name | Type | Definition | Required |
 | ----- | ---- | ---- | ---------- | -------- |
 | **plan_name** | Plan Name | String | The plan's name. | Yes |
+| **issuer_name** | Issuer Name | String | The name of the plan's issuer. | Yes |
 | **plan_id_type** | Plan Id Type | String | Allowed values: "ein" and "hios" | Yes |
-| **plan_sponsor_name** | Plan Sponsor Name | String | 	If the `plan_id_type` is "ein", the common business name of the plan sponsor | No |
+| **plan_sponsor_name** | Plan Sponsor Name | String | 	If the `plan_id_type` is "ein", the common business name of the plan sponsor is required. | No |
 | **plan_market_type** | Market Type | String | Allowed values: "group" and "individual" | Yes |
 
 #### File Location Object

--- a/schemas/table-of-contents/table-of-contents.json
+++ b/schemas/table-of-contents/table-of-contents.json
@@ -59,6 +59,10 @@
           "type": "string",
           "minLength": 1
         },
+        "issuer_name": {
+          "type": "string",
+          "minLength": 1
+        },
         "plan_id_type": {
           "enum": ["ein", "hios"]
         },
@@ -80,7 +84,7 @@
       "then": {
         "required": ["plan_sponsor_name"]
       },
-      "required": ["plan_name", "plan_id_type", "plan_id", "plan_market_type"]
+      "required": ["plan_name", "plan_id_type", "plan_id", "plan_market_type", "issuer_name"]
     }
   },
   "type": "object",


### PR DESCRIPTION
Adding documentation for the `plan_sponsor_name` attribute in the table of contents.