### PR TITLE
Included SOI attribute for DRG types.

### DIFF
--- a/schemas/in-network-rates/README.md
+++ b/schemas/in-network-rates/README.md
@@ -28,6 +28,7 @@ This type defines an in-network object.
 | **name** | Name | String | This is name of the item/service that is offered | Yes |
 | **billing_code_type** | Billing Code Type | String | Common billing code types. Please see a list of the [currently allowed codes](#additional-notes-concerning-billing_code_type) at the bottom of this document. | Yes |
 | **billing_code_type_version** | Billing Code Type Version | String | There might be versions associated with the `billing_code_type`. For example, Medicare's current (as of 5/24/21) MS-DRG version is 37.2. If there is no version available for the `billing_code_type`, use the current plan's year `YYYY` that is being disclosed.  | Yes |
+| **severity_of_illness** | Severity Of Illness | String | Various DRG billing code type negotiated rates are dependent on a severity of illness (SOI). If a DRG's negotiated rates is based on a SOI, the SOI value is to be included. | No |
 | **billing_code** | Billing Code | String | The code used by a plan or issuer or its in-network providers to identify health care items or services for purposes of billing, adjudicating, and paying claims for a covered item or service. If a custom code is used for `billing_code_type`, please refer to [custom billing code values](#additional-notes-concerning-billing_code) |  Yes |
 | **description** | Description | String | Brief description of the item/service | Yes |
 | **negotiated_rates** | Negotiated Rates | Array | This is an array of [negotiated rate details object types](#negotiated-rate-details-object) | Yes |

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -15,6 +15,10 @@
         "billing_code_type": {
           "$ref": "#/definitions/billing_code_types"
         },
+        "severity_of_illness": {
+          "type": "string",
+          "minLength": 1
+        },
         "billing_code_type_version": {
           "type": "string",
           "minLength": 1


### PR DESCRIPTION
Adding a `severity_of_illness` contextual attribute to clarity DRG type negotiated rates.