### PR TITLE
Update README.md allowed amount 2.0

### DIFF
--- a/schemas/allowed-amounts/README.md
+++ b/schemas/allowed-amounts/README.md
@@ -4,9 +4,11 @@
 | ----- | ---- | ---- | ---------- | -------- |
 | **reporting_entity_name** | Entity Name | String | The legal name of the entity publishing the machine-readable file. | Yes |
 | **reporting_entity_type** | Entity Type | String | The type of entity that is publishing the machine-readable file (a group health plan, health insurance issuer, or a third party with which the plan or issuer has contracted to provide the required information, such as a third-party administrator, a health care claims clearinghouse, or a health insurance issuer that has contracted with a group health plan sponsor). | Yes |
-| **plan_name** | Plan Name | String | The plan name and name of plan sponsor and/or insurance company. | No |
+| **issuer_name** |	Issuer Name	| String | The name of the plan's issuer. |	No |
+| **plan_name** | Plan Name | String | The plan name. | No |
 | **plan_id_type** | Plan Id Type | String | Allowed values: "EIN" and "HIOS" | No |
 | **plan_id** | Plan ID | String | The 10-digit Health Insurance Oversight System (HIOS) identifier, or, if the 10-digit HIOS identifier is not available, the 5-digit HIOS identifier, or if no HIOS identifier is available, the Employer Identification Number (EIN)for    each plan or coverage offered by a plan or issuer. | No |
+| **plan_sponsor_name** | Plan Name | String | If the plan_id_type is "EIN", the common business name of the plan sponsor. | No |
 | **plan_market_type** | Market Type | String | Allowed values: "group" and "individual" | No |
 | **out_of_network** | Out Of Network | Array | An array of [out-of-network object types](#out-of-network-object) | Yes |
 | **last_updated_on** | Last Updated On | String | The date in which the file was last updated. Date must be in an ISO 8601 format (i.e. YYYY-MM-DD) | Yes |
@@ -37,6 +39,7 @@ The allowed amounts object documents the entity or business and service code in 
 | **tin** | Tax Identification Number | Object | The [tax identifier object](#tas-identifier-object) contains tax information on the place of business | Yes |
 | **service_code** | Place of Service Code | An array of two-digit strings | The [CMS-maintained two-digit code](https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set) that is placed on a professional claim to indicate the setting in which a service was provided. When attribute of `billing_class` has the value of "professional", `service_code` is required.  | No |
 | **billing_class** | Billing Class | String | Allowed values: "professional", "institutional" | Yes |
+| **setting** | Setting | String | Allowed values: "inpatient", "outpatient", "both" | Yes |
 | **payments** | Payments |	Array | An array of [out-of-network payments objects](#out-of-network-payment-object) | Yes |
 
 #### Tax Identifier Object


### PR DESCRIPTION
Why wouldn't issuer name, plan sponsor name and setting be added to allowed amount MRF schema to align with other 2.0 schema changes?  @shaselton-usds @shaselton 