### PR TITLE
Update allowed-amounts-single-plan-sample.json with issuer name, plan…

### DIFF
--- a/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
+++ b/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
@@ -24,7 +24,6 @@
           },
           "service_code": ["01", "02", "03"],
           "billing_class": "professional",
-          "setting": "outpatient",
           "payments": [
             {
               "allowed_amount": 25.0,


### PR DESCRIPTION
… sponsor name

updated to represent 'ein' plan id type, where plan sponsor name and issuer name are represented for version 2.0.0 schema