### PR TITLE
Update allowed-amounts-single-plan-sample.json

### DIFF
--- a/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
+++ b/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
@@ -2,11 +2,13 @@
   "reporting_entity_name": "cms",
   "reporting_entity_type": "cms",
   "plan_name": "medicare",
-  "plan_id_type": "hios",
-  "plan_id": "1111111111",
+  "issuer_name": "issuer example name",
+  "plan_id_type": "ein",
+  "plan_id": "231090909",
+  "plan_sponsor_name": "sponsor name example",
   "plan_market_type": "individual",
-  "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "last_updated_on": "2025-02-01",
+  "version": "2.0.0",
   "out_of_network": [
     {
       "name": "Established Patient Office or Other Outpatient Services",
@@ -22,7 +24,6 @@
           },
           "service_code": ["01", "02", "03"],
           "billing_class": "professional",
-          "setting": "outpatient",
           "payments": [
             {
               "allowed_amount": 25.0,


### PR DESCRIPTION
revising to include issuer_name, switch to 'ein' example for plan_sponsor_name and remove the 'setting' field, as it is not in the allowed amount schema 2.0