### PR TITLE
Update allowed-amounts-multiple-plan-sample.json

### DIFF
--- a/examples/allowed-amounts/allowed-amounts-multiple-plan-sample.json
+++ b/examples/allowed-amounts/allowed-amounts-multiple-plan-sample.json
@@ -2,7 +2,7 @@
   "reporting_entity_name": "cms",
   "reporting_entity_type": "cms",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "out_of_network": [
     {
       "name": "Established Patient Office or Other Outpatient Services",
@@ -18,7 +18,6 @@
           },
           "service_code": ["01", "02", "03"],
           "billing_class": "professional",
-          "setting": "outpatient",
           "payments": [
             {
               "allowed_amount": 25.0,


### PR DESCRIPTION
removed the setting field from example, as not in 2.0 schema