### PR TITLE
Updates the JSON versions to 2.0.0

### DIFF
--- a/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
@@ -7,7 +7,7 @@
   "plan_id": "0000000000",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
@@ -6,7 +6,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
@@ -8,7 +8,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "group",
   "last_updated_on": "2020-08-27",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
+++ b/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
@@ -2,7 +2,7 @@
   "reporting_entity_name": "cms",
   "reporting_entity_type": "cms",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references":[{
     "provider_group_id": 1,
     "network_name": ["ACME Choice Provider Group"],

--- a/examples/in-network-rates/in-network-rates-no-npi.json
+++ b/examples/in-network-rates/in-network-rates-no-npi.json
@@ -8,7 +8,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,


### PR DESCRIPTION
Per https://github.com/CMSgov/price-transparency-guide/issues/864, it looks like the version in the JSON examples needs to be update to 2.0.0. 

Judging from the XML examples, it does not look like these files have been upgraded to the new spec yet (tin don't include the business names) so I left the version alone in those files.