### PR TITLE
Refactor service_code pattern validation

### DIFF
--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -130,14 +130,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "oneOf": [
-              {
-                "pattern": "^([1-9][0-9]|[0-9][1-9])$"
-              },
-              {
-                "const": "CSTM-00"
-              }
-            ]
+            "pattern": "^(0[1-9]|[1-9][0-9]|CSTM-00)$"
           },
           "uniqueItems": true
         },


### PR DESCRIPTION
To simplify, and addresses what appears to be a bug in the json validator's handling of the CSTM-00 const in the oneOf criteria when used in conjunction with the Place of Service code pattern.  The schema looked correct to me but in my environment the const behaved as a wild card.  Valid POS codes would fail 100% of the time due to matching both the pattern and the const.  Adding minLength=7 and maxLength=7 would get the pattern working correctly but any 7 digit value would also be accepted. Validator output before this fix:
Error Name: oneOf
Message: Property matched more than one of the sub-schemas specified by 'oneOf'. Instance: #/in_network/0/negotiated_rates/0/negotiated_prices/0/service_code/0 Schema: #/definitions/negotiated_price/properties/service_code/items