### PR TITLE
removing left over setting attribute in the allowed amount field

### DIFF
--- a/schemas/allowed-amounts/allowed-amounts.json
+++ b/schemas/allowed-amounts/allowed-amounts.json
@@ -91,12 +91,6 @@
             "institutional"
           ]
         },
-        "setting": {
-          "enum": [
-            "inpatient",
-            "outpatient"
-          ]
-        },
         "payments": {
           "type": "array",
           "items": {
@@ -109,7 +103,6 @@
       "required": [
         "tin",
         "billing_class",
-        "setting",
         "payments"
       ],
       "if": {


### PR DESCRIPTION
Removing the extra `setting` attribute found in the allowed amounts file. Discussion #854