### PR TITLE
updating json examples to include 2.0.0 in the version attribute.

### DIFF
--- a/examples/allowed-amounts/allowed-amounts-multiple-plan-sample.json
+++ b/examples/allowed-amounts/allowed-amounts-multiple-plan-sample.json
@@ -2,7 +2,7 @@
   "reporting_entity_name": "cms",
   "reporting_entity_type": "cms",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "out_of_network": [
     {
       "name": "Established Patient Office or Other Outpatient Services",

--- a/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
+++ b/examples/allowed-amounts/allowed-amounts-single-plan-sample.json
@@ -6,7 +6,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "out_of_network": [
     {
       "name": "Established Patient Office or Other Outpatient Services",

--- a/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-bundle-single-plan-sample.json
@@ -7,7 +7,7 @@
   "plan_id": "0000000000",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-capitation-single-plan-sample.json
@@ -6,7 +6,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
+++ b/examples/in-network-rates/in-network-rates-fee-for-service-single-plan-sample.json
@@ -8,7 +8,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "group",
   "last_updated_on": "2020-08-27",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,

--- a/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
+++ b/examples/in-network-rates/in-network-rates-multiple-plans-sample.json
@@ -2,7 +2,7 @@
   "reporting_entity_name": "cms",
   "reporting_entity_type": "cms",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references":[{
     "provider_group_id": 1,
     "network_name": ["ACME Choice Provider Group"],

--- a/examples/in-network-rates/in-network-rates-no-npi.json
+++ b/examples/in-network-rates/in-network-rates-no-npi.json
@@ -8,7 +8,7 @@
   "plan_id": "1111111111",
   "plan_market_type": "individual",
   "last_updated_on": "2020-08-27",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "provider_references": [
     {
       "provider_group_id": 1,


### PR DESCRIPTION
Updating json examples to include the "2.0.0" value for the `version` attribute.

Thank you @jamesonnetworks-clearcost for the PR #865 -- I updated a couple more spots where the version was still reflecting "1.x.x". I am going to close out your PR with thanks!