### PR TITLE
Revert to JSON schema draft-04 to address RapidJSON validator issues

### DIFF
--- a/schemas/allowed-amounts/allowed-amounts.json
+++ b/schemas/allowed-amounts/allowed-amounts.json
@@ -232,8 +232,7 @@
       "items": {
         "$ref": "#/definitions/out_of_network"
       },
-      "default": [],
-      "minItems": 1
+      "default": []
     }
  },
  "required": [

--- a/schemas/allowed-amounts/allowed-amounts.json
+++ b/schemas/allowed-amounts/allowed-amounts.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://github.com/CMSgov/price-transparency-guide/blob/master/schemas/allowed-amounts/allowed-amounts.json",
   "definitions": {
     "out_of_network": {
@@ -81,7 +81,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^([1-9][0-9]|[0-9][1-9])$"
+            "pattern": "^(0[1-9]|1[0-9]|2[0-7]|3[1-4]|4[1-2]|4[9]|5[0-8]|6[0-2]|6[5-6]|7[1-2]|81|99)$"
           },
           "uniqueItems": true
         },
@@ -105,18 +105,20 @@
         "billing_class",
         "payments"
       ],
-      "if": {
-        "properties": {
-          "billing_class": {
-            "const": "professional"
-          }
+      "oneOf": [
+        {
+          "properties": {
+            "billing_class": { "enum": ["professional"] }
+          },
+          "required": ["billing_class", "service_code"]
+        },
+        {
+          "properties": {
+            "billing_class": { "enum": ["institutional"] }
+          },
+          "required": ["billing_class"]
         }
-      },
-      "then": {
-        "required": [
-          "service_code"
-        ]
-      }
+      ]
     },
     "payments": {
       "type": "object",
@@ -195,9 +197,14 @@
       "minLength": 1
     },
     "plan_id_type": {
-      "enum": [
-        "ein",
-        "hios"
+      "oneOf": [
+        {
+            "enum": ["ein"],
+            "required": ["plan_sponsor_name"]
+        },
+        {
+            "enum": ["hios"]
+        }
       ]
     },
     "plan_id": {
@@ -228,25 +235,8 @@
       "default": [],
       "minItems": 1
     }
-  },
-  "if": {
-    "properties": {
-      "plan_id_type": {
-        "enum": [
-          "ein"
-        ]
-      }
-    },
-    "required": [
-      "plan_id_type"
-    ]
-  },
-  "then": {
-    "required": [
-      "plan_sponsor_name"
-    ]
-  },
-  "required": [
+ },
+ "required": [
     "reporting_entity_name",
     "reporting_entity_type",
     "last_updated_on",

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://github.com/CMSgov/price-transparency-guide/blob/master/schemas/in-network-rates/in-network-rates.json",
   "definitions": {
     "in_network": {
@@ -140,7 +140,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "pattern": "^CSTM-00$"
+                "enum": ["CSTM-00"]
               },
               "maxItems": 1
             }
@@ -180,7 +180,7 @@
         },
         "negotiated_rate": {
           "type": "number",
-          "exclusiveMinimum": 0
+          "minimum": 0.000001
         },
         "expiration_date": {
           "type": "string",
@@ -195,25 +195,27 @@
           "minLength": 1
         }
       },
+      "oneOf": [
+        {
+          "properties": {
+            "billing_class": { "enum": ["professional"] }
+          },
+          "required": ["billing_class", "service_code"]
+        },
+        {
+          "properties": {
+            "billing_class": { "enum": ["institutional", "both"] }
+          },
+          "required": ["billing_class"]
+        }
+      ],
       "required": [
         "negotiated_type",
         "billing_class",
         "negotiated_rate",
         "expiration_date",
         "setting"
-      ],
-      "if": {
-        "properties": {
-          "billing_class": {
-            "const": "professional"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "service_code"
-        ]
-      }
+      ]
     },
     "providers": {
       "type": "object",
@@ -260,7 +262,7 @@
             {
               "properties": {
                 "type": {
-                  "pattern": "^ein$"
+                  "enum": ["ein"]
                 },
                 "value": {
                   "pattern": "^[0-9]{2}-?[0-9]{7}$"
@@ -271,7 +273,7 @@
             {
               "properties": {
                 "type": {
-                  "pattern": "^npi$"
+                  "enum": ["npi"]
                 },
                 "value": {
                   "pattern": "^[1-9][0-9]{9}$"
@@ -332,9 +334,14 @@
       "minLength": 1
     },
     "plan_id_type": {
-      "enum": [
-        "ein",
-        "hios"
+      "oneOf": [
+          {
+              "enum": ["ein"],
+              "required": ["plan_sponsor_name"]
+          },
+          {
+              "enum": ["hios"]
+          }
       ]
     },
     "plan_id": {
@@ -371,7 +378,6 @@
             "items": {
               "$ref": "#/definitions/providers"
             },
-            "default": [],
             "minItems": 1
           },
           "network_name": {
@@ -388,7 +394,7 @@
           "network_name"
         ]
       },
-      "minLength": 1
+      "minItems": 1
     },
     "in_network": {
       "type": "array",
@@ -398,23 +404,6 @@
       "default": [],
       "minItems": 1
     }
-  },
-  "if": {
-    "properties": {
-      "plan_id_type": {
-        "enum": [
-          "ein"
-        ]
-      }
-    },
-    "required": [
-      "plan_id_type"
-    ]
-  },
-  "then": {
-    "required": [
-      "plan_sponsor_name"
-    ]
   },
   "required": [
     "reporting_entity_name",

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -334,15 +334,8 @@
       "minLength": 1
     },
     "plan_id_type": {
-      "oneOf": [
-          {
-              "enum": ["ein"],
-              "required": ["plan_sponsor_name"]
-          },
-          {
-              "enum": ["hios"]
-          }
-      ]
+      "type": "string",
+      "enum": ["ein","hios"]
     },
     "plan_id": {
       "type": "string",
@@ -411,6 +404,41 @@
     "last_updated_on",
     "in_network",
     "version"
+  ],
+  "oneOf": [
+    {
+      "properties": {
+        "plan_id_type": { "enum": ["ein"] }
+      },
+      "required": [
+        "reporting_entity_name",
+        "reporting_entity_type",
+        "last_updated_on",
+        "in_network",
+        "version",
+        "plan_id_type",
+        "plan_id",
+        "plan_market_type",
+        "issuer_name",
+        "plan_sponsor_name"
+      ]
+    },
+    {
+      "properties": {
+        "plan_id_type": { "enum": ["hios"] }
+      },
+      "required": [
+        "reporting_entity_name",
+        "reporting_entity_type",
+        "last_updated_on",
+        "in_network",
+        "version",
+        "plan_id_type",
+        "plan_id",
+        "plan_market_type",
+        "issuer_name"
+      ]
+    }
   ],
   "dependencies": {
     "plan_name": [

--- a/schemas/in-network-rates/in-network-rates.json
+++ b/schemas/in-network-rates/in-network-rates.json
@@ -406,6 +406,7 @@
     "version"
   ],
   "oneOf": [
+    {"not": {"required": ["plan_id_type"]}},
     {
       "properties": {
         "plan_id_type": { "enum": ["ein"] }

--- a/schemas/table-of-contents/table-of-contents.json
+++ b/schemas/table-of-contents/table-of-contents.json
@@ -73,15 +73,8 @@
           "minLength": 1
         },
         "plan_id_type": {
-          "oneOf": [
-              {
-                  "enum": ["ein"],
-                  "required": ["plan_sponsor_name"]
-              },
-              {
-                  "enum": ["hios"]
-              }
-          ]
+          "type": "string",
+           "enum": ["ein","hios"]
         },
         "plan_id": {
           "type": "string",
@@ -104,6 +97,20 @@
         "plan_id",
         "plan_market_type",
         "issuer_name"
+      ],
+      "oneOf": [
+        {
+          "properties": {
+            "plan_id_type": { "enum": ["ein"] }
+          },
+          "required": ["plan_id_type", "plan_id", "plan_sponsor_name"]
+        },
+        {
+          "properties": {
+            "plan_id_type": { "enum": ["hios"] }
+          },
+          "required": ["plan_id_type", "plan_id"]
+        }
       ]
     }
   },

--- a/schemas/table-of-contents/table-of-contents.json
+++ b/schemas/table-of-contents/table-of-contents.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://github.com/CMSgov/price-transparency-guide/blob/master/schemas/table-of-contents/table-of-contents.json",
   "definitions": {
     "file_location": {
@@ -68,21 +68,26 @@
           "type": "string",
           "minLength": 1
         },
-        "plan_sponsor_name": {
-          "type": "string",
-          "minLength": 1
-        },
         "issuer_name": {
           "type": "string",
           "minLength": 1
         },
         "plan_id_type": {
-          "enum": [
-            "ein",
-            "hios"
+          "oneOf": [
+              {
+                  "enum": ["ein"],
+                  "required": ["plan_sponsor_name"]
+              },
+              {
+                  "enum": ["hios"]
+              }
           ]
         },
         "plan_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "plan_sponsor_name": {
           "type": "string",
           "minLength": 1
         },
@@ -92,20 +97,6 @@
             "individual"
           ]
         }
-      },
-      "if": {
-        "properties": {
-          "plan_id_type": {
-            "enum": [
-              "ein"
-            ]
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "plan_sponsor_name"
-        ]
       },
       "required": [
         "plan_name",


### PR DESCRIPTION
Schema changes to enforce constraints which were being bypassed due to dependencies on unsupported JSON Schema draft-07 functionality.

Unsupported functionality replaced :
```
   const
   if .. then
   exclusiveMinimum

```