### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CMS Transparency in Coverage](resources/images/TiC_banner.png?raw=true "Transparency in Coverage")](https://www.cms.gov/healthplan-price-transparency)
 
 # Transparency in Coverage
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CMSgov/price-transparency-guide)
 This is the technical implementation guide for the machine readable files as required by the [Transparency in Coverage](https://www.federalregister.gov/documents/2020/11/12/2020-24591/transparency-in-coverage) final rules (85 FR 72158). 
 
 If you are looking for the technical implementation guide for the machine readable files required by the [Hospital Price Transparency](https://www.cms.gov/priorities/key-initiatives/hospital-price-transparency) final rules (45 CFR 180), please go to https://github.com/CMSgov/hospital-price-transparency.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/CMSgov/price-transparency-guide) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.